### PR TITLE
Create .babelrc to fix runtime error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "transform-runtime",
+    "transform-decorators"
+  ],
+  "presets": [
+    "es2015", 
+    "react", 
+    "stage-0"
+  ]
+}


### PR DESCRIPTION
### Error

```
(function (exports, require, module, __filename, __dirname) { import { combineReducers } from 'redux';
                                                              ^^^^^^

SyntaxError: Unexpected token import
```
